### PR TITLE
Update food.gd

### DIFF
--- a/Scenes/game.tscn
+++ b/Scenes/game.tscn
@@ -12,9 +12,6 @@ scale = Vector2(1.14, 1.14)
 texture = ExtResource("1_6ttki")
 centered = false
 
-[node name="ItemSlot" parent="." instance=ExtResource("1_maf3u")]
-position = Vector2(201, 202)
-
 [node name="ItemSlot2" parent="." instance=ExtResource("1_maf3u")]
 position = Vector2(163, 562)
 
@@ -44,9 +41,6 @@ position = Vector2(645, 385)
 
 [node name="ItemSlot17" parent="." instance=ExtResource("1_maf3u")]
 position = Vector2(291, 385)
-
-[node name="ItemSlot18" parent="." instance=ExtResource("1_maf3u")]
-position = Vector2(42, 296)
 
 [node name="DraggableObject" parent="." instance=ExtResource("1_8m1q7")]
 position = Vector2(201, 202)

--- a/Scripts/food.gd
+++ b/Scripts/food.gd
@@ -58,7 +58,7 @@ func _on_area_2d_body_exited(body):
 func _create_clone():
 	var node = load(food_prefab_path)
 	var instance = node.instantiate()
-	instance.position = body_ref.position
-	instance.initial_position = body_ref.position
+	instance.position = initial_position
+	instance.initial_position = initial_position
 	add_sibling(instance)
 	


### PR DESCRIPTION
- Initial food prefab no longer requires placement of an item slot behind it
- Deleted item slots behind initial food prefabs